### PR TITLE
refs #24326 use correct variable for setting archive deletion threshold

### DIFF
--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -88,7 +88,7 @@ class API extends \Piwik\Plugin\API
 
         // If using the feature "Delete logs older than N days"...
         $purgeDataSettings = PrivacyManager::getPurgeDataSettings();
-        $logsAreDeletedBeforeThisDate = $purgeDataSettings['delete_logs_schedule_lowest_interval'];
+        $logsAreDeletedBeforeThisDate = $purgeDataSettings['delete_logs_older_than'];
         $logsDeleteEnabled = $purgeDataSettings['delete_logs_enable'];
         $minimumDateWithLogs = false;
         if ($logsDeleteEnabled


### PR DESCRIPTION
We can't apply the exact change from the commit that fixed the issue, since piwik - specifically plugins/CoreAdminHome/API.php has been refactor multiple times between our version and the when the fix was introduced. The following change should accomplish what we want though.